### PR TITLE
Fix basic unit test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -504,5 +504,5 @@ gulp.task('watch', 'Run developer watch modus.', () => {
         path.join(settings.NODE_PATH, 'vjs-mod-*', 'src', 'components', '**', '*.vue'),
     ], ['templates'])
 
-    gulp.watch(path.join(settings.ROOT_DIR, 'test', 'bg', '**', '*.js'), ['test-unit'])
+    gulp.watch([path.join(settings.ROOT_DIR, 'test', 'bg', '**', '*.js')], ['test-unit'])
 })

--- a/src/js/lib/app.js
+++ b/src/js/lib/app.js
@@ -274,8 +274,11 @@ class App extends Skeleton {
             const options = this.state.settings.language.options
             // Try to figure out the language from the environment.
             // Check only the first part of en-GB/en-US.
-            if (this.env.isBrowser) language = options.find((i) => i.id === navigator.language.split('-')[0])
-            else language = options.find((i) => i.id === process.env.LANGUAGE.split('_')[0])
+            if (this.env.isBrowser) {
+                language = options.find((i) => i.id === navigator.language.split('-')[0])
+            } else if (process.env.LANGUAGE) {
+                language = options.find((i) => i.id === process.env.LANGUAGE.split('_')[0])
+            }
             // Fallback to English language as a last resort.
             if (!language) language = options.find((i) => i.id === 'en')
         }


### PR DESCRIPTION
## Purpose

Unit test `test/basic.js` was broken because `process.env.LANGUAGE` was not set.

## Approach

Fallback to default language if `process.env.LANGUAGE` is not specified.

#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning

Also changed the gulp watch task to re-run all unit tests if any of the `*.js` source files change, not just the the `js` files of the tests.
