### PR TITLE
Add direnv with Nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+use_nix
+PATH_add node_modules/.bin
+
+# replace broken optipng with nix version.
+rm node_modules/.bin/optipng
+mkdir -p node_modules/optipng-bin/vendor
+ln -sf $(which optipng) node_modules/optipng-bin/vendor/optipng

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 build
 dist
 docs/screenshots
-package-lock.json
 super_secret.txt
 .tags
 .publish

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "git.ignoreLimitWarning": true,
+    "files.exclude": {
+        "**/*.git": true,
+        ".idea": true,
+        "build": true,
+    },
+    "files.associations": {
+        "*.vue": "vue-html",
+        "*.vialer-jsrc": "json",
+    }
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,17 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+
+with nixpkgs;
+
+mkShell {
+  buildInputs = [
+    # node runtime.
+    nodejs-10_x
+
+    # for compiling optipng, gifsicle and jpegtran
+    # autoconf zlib nasm automake
+
+    optipng
+    gifsicle
+    libjpeg  # for jpegtran
+  ];
+}

--- a/tools/settings.js
+++ b/tools/settings.js
@@ -103,6 +103,7 @@ module.exports = function(baseDir, overrides) {
     gutil.log(`- PRODUCTION: ${settings.PRODUCTION}`)
     gutil.log(`- TARGET: ${settings.BUILD_TARGET}`)
     gutil.log(`- VERBOSE: ${settings.VERBOSE}`)
+    gutil.log(`- LIVERELOAD: ${settings.LIVERELOAD}`)
 
     return settings
 }


### PR DESCRIPTION
## Purpose

Added an `.envrc` file to be used with [direnv](https://direnv.net/) that uses [Nix](https://nixos.org/nix/) to setup a basic environment in which to run the build of vialer-js.

Also removed package-lock.json from the ignore as I think it's important to keep this in the repository for reproducible builds.

## Approach


#### Open Questions and Pre-Merge TODOs
- [ ] Use github checklists. When solved, check the box and explain the answer.

## Learning

