### PR TITLE
Run sass lint in pre commit hook

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -2,6 +2,7 @@
 
 options:
     formatter: stylish
+    max-warnings: 0
 
 files:
     include: '**/*.scss'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,6 +34,7 @@ const test = require('tape')
 const eslint = require('gulp-eslint')
 const guppy = require('git-guppy')(gulp)
 const filter = require('gulp-filter')
+const sassLint = require('gulp-sass-lint')
 
 
 const writeFileAsync = promisify(fs.writeFile)
@@ -401,7 +402,7 @@ gulp.task('test-unit', 'Run unit and integation tests.', () => {
 })
 
 
-gulp.task('lint', () => {
+gulp.task('lint-js', () => {
     return gulp.src(['src/**/*.js', 'test/**/*.js', 'gulpfile.js'])
         .pipe(eslint())
         .pipe(eslint.format())
@@ -409,12 +410,36 @@ gulp.task('lint', () => {
 })
 
 
-gulp.task('pre-commit-lint', () => {
+gulp.task('lint-sass', () => {
+    return gulp.src(['src/**/*.scss'])
+        .pipe(sassLint({
+            config: '.sass-lint.yml',
+        }))
+        .pipe(sassLint.format())
+        .pipe(sassLint.failOnError())
+})
+
+
+gulp.task('lint', ['lint-js', 'lint-sass'])
+
+
+gulp.task('pre-commit-lint-js', () => {
     return guppy.stream('pre-commit')
         .pipe(filter(['*.js']))
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError())
+})
+
+
+gulp.task('pre-commit-lint-sass', () => {
+    return guppy.stream('pre-commit')
+        .pipe(filter(['*.scss']))
+        .pipe(sassLint({
+            config: '.sass-lint.yml',
+        }))
+        .pipe(sassLint.format())
+        .pipe(sassLint.failOnError())
 })
 
 
@@ -432,7 +457,8 @@ gulp.task('pre-commit-protect-secrets', () => {
 
 
 gulp.task('pre-commit', [
-    'pre-commit-lint',
+    'pre-commit-lint-js',
+    'pre-commit-lint-sass',
     'pre-commit-protect-secrets',
     'test-unit',
 ])

--- a/package-lock.json
+++ b/package-lock.json
@@ -8057,6 +8057,115 @@
                 }
             }
         },
+        "gulp-sass-lint": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/gulp-sass-lint/-/gulp-sass-lint-1.4.0.tgz",
+            "integrity": "sha512-XerYvHx7rznInkedMw5Ayif+p8EhysOVHUBvlgUa0FSl88H2cjNjaRZ3NGn5Efmp+2HxpXp4NHqMIbOSdwef3A==",
+            "dev": true,
+            "requires": {
+                "plugin-error": "^0.1.2",
+                "sass-lint": "^1.12.0",
+                "through2": "^2.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+                    "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
+                    }
+                },
+                "arr-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+                    "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+                    "dev": true
+                },
+                "array-slice": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+                    "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+                    "dev": true
+                },
+                "extend-shallow": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+                    "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^1.1.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "1.1.0",
+                    "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+                    "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+                    "dev": true
+                },
+                "plugin-error": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+                    "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-cyan": "^0.1.1",
+                        "ansi-red": "^0.1.1",
+                        "arr-diff": "^1.0.1",
+                        "arr-union": "^2.0.1",
+                        "extend-shallow": "^1.1.2"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                    "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "^2.1.5",
+                        "xtend": "~4.0.1"
+                    }
+                },
+                "xtend": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                    "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+                    "dev": true
+                }
+            }
+        },
         "gulp-sentry-release-manager": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/gulp-sentry-release-manager/-/gulp-sentry-release-manager-0.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     },
     "scripts": {
         "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
-        "test": "gulp test-unit;gulp test-browser",
+        "test": "gulp test-unit; gulp test-browser",
         "link": "npm link vjs-adapter-user-vg;npm link vjs-adapter-user-voip;npm link vjs-addon-availability-vg;npm link vjs-mod-queues-vg;npm link vjs-provider-contacts-vg;npm link jsdoc-rtd; npm link gulp-fuet",
-        "lint-js": "./node_modules/.bin/eslint './src/**/*.js'",
-        "lint-scss": "./node_modules/sass-lint/bin/sass-lint.js -v -c ./.sass-lint.yml 'src/**/*.scss' --max-warnings 0"
+        "lint-js": "gulp lint-js",
+        "lint-scss": "gulp lint-sass"
     },
     "repository": {
         "type": "git",
@@ -69,6 +69,7 @@
         "gulp-notify": "3.x.x",
         "gulp-rename": "1.x.x",
         "gulp-sass": "3.x.x",
+        "gulp-sass-lint": "^1.4.0",
         "gulp-sentry-release-manager": "0.0.x",
         "gulp-size": "2.x.x",
         "gulp-sourcemaps": "2.x.x",

--- a/src/scss/vialer-js/lib/animations.scss
+++ b/src/scss/vialer-js/lib/animations.scss
@@ -67,27 +67,21 @@
 
 .animated {
     -webkit-animation-duration: .5s;
-    animation-duration: .5s;
     -webkit-animation-fill-mode: both;
-    animation-fill-mode: both;
-    -webkit-animation-timing-function: linear;
-    animation-timing-function: linear;
-    animation-iteration-count: infinite;
     -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: linear;
+    animation-duration: .5s;
+    animation-fill-mode: both;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
 }
+
 @-webkit-keyframes bounce {
-    0%, 100% {
-        -webkit-transform: translateY(0);
-    }
-    50% {
-        -webkit-transform: translateY(-1px);
-    }
+    0%, 100% { -webkit-transform: translateY(0); }
+    50% { -webkit-transform: translateY(-1px); }
 }
+
 @keyframes bounce {
-    0%, 100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-1px);
-    }
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-1px); }
 }

--- a/test/bg/observer/parser.js
+++ b/test/bg/observer/parser.js
@@ -1,3 +1,4 @@
+/* eslint-disable sort-keys */
 const test = require('tape')
 const { JSDOM } = require('jsdom')
 const { document } = new JSDOM().window
@@ -8,17 +9,17 @@ const parsers = require('../../../src/js/observer/parsers')
 
 test('[bg] test parsing NL numbers', (t) => {
     function parse(str) {
-        const parser = parsers.find(([locale, _]) => locale == 'NL')[1]()
+        const parser = parsers.find(([locale, _]) => locale === 'NL')[1]()
         return parser.parse(str)
     }
 
     function match(str, expected, msg) {
-        name = msg || `'${str}'`
+        const name = msg || `'${str}'`
         t.deepEqual(parse(str), expected, `${name} matches`)
     }
 
     function noMatch(str, msg) {
-        name = msg || `'${str}'`
+        const name = msg || `'${str}'`
         t.deepEqual(parse(str), [], `${name} does not match`)
     }
 
@@ -65,7 +66,8 @@ test('[bg] test parsing NL numbers', (t) => {
     match('06-12345678', [ { start: 0, end: 11, number: '0612345678' } ])
     match('06-12345678 -', [ { start: 0, end: 12, number: '0612345678' } ])
 
-    match(`<p>
+    match(
+        `<p>
         Tel&nbsp; 0501-123456<br />
         T 0501-123457<br />
         Fax 0501-123458<br />
@@ -77,8 +79,8 @@ test('[bg] test parsing NL numbers', (t) => {
         ],
         'Two phonenumbers and ignore two faxnumbers')
 
-    match(`
-        <td style="width: 200px">Pietje Puk<br />
+    match(
+        `<td style="width: 200px">Pietje Puk<br />
         De Brandstraat 123<br />
         1234 AB&nbsp; Plaats<br />
         &nbsp;<br />
@@ -92,7 +94,7 @@ test('[bg] test parsing NL numbers', (t) => {
         <br />
         <strong>Openingstijden</strong>
         </td>`,
-        [ { start: 158, end: 169, number: '0501123457' } ],
+        [ { start: 149, end: 160, number: '0501123457' } ],
         'Contact details in a TD')
 
     match('050 1234 121', [ { start: 0, end: 12, number: '0501234121' } ])


### PR DESCRIPTION
## Purpose

Run sass-lint in pre-commit hook to prevent commiting files with sass lint errors.

Unfortunately it won't fail on sass lint warnings, there is a patch for that (https://github.com/sasstools/gulp-sass-lint/pull/72) but it was rejected by the author.