### PR TITLE
VIALJS-112: Fixed issues with the timing of saving settings and the verify-sinks bg call.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "debug-vialer-webview",
+            "type": "chrome",
+            "request": "attach",
+            "port": 9222,
+            "url": "http://localhost:8999",
+            "webRoot": "${workspaceRoot}/build/vialer/webview",
+            "sourceMaps": true,
+            "trace": true,
+            "sourceMapPathOverrides": {
+                "*": "${workspaceRoot}/*",
+            },
+        },
+    ]
+}

--- a/src/components/settings/index.js
+++ b/src/components/settings/index.js
@@ -31,15 +31,16 @@ module.exports = (app) => {
                         delete settings.webrtc.account.selected
                         app.setState({availability: {dnd: false}, settings}, {persist: true})
                         app.emit('bg:calls:connect')
+
+                        app.notify({icon: 'settings', message: app.$t('settings are updated.'), type: 'success'})
+
+                        // Verify currently selected devices after saving settings again.
+                        app.emit('bg:devices:verify-sinks')
                     },
                 }, 'both')
 
                 // Update the vault settings.
                 app.setState({app: {vault: this.app.vault}}, {encrypt: false, persist: true})
-                app.notify({icon: 'settings', message: app.$t('settings are updated.'), type: 'success'})
-
-                // Verify currently selected devices after saving settings again.
-                app.emit('bg:devices:verify-sinks')
             },
         }, app.helpers.sharedMethods()),
         mounted: async function() {


### PR DESCRIPTION
## Purpose

Saving settings after changing redundant headset doesn't remove them immediately.

To reproduce: set a usb device as your audio device(s) in Vialer-js settings and save. Remove the device. You'll be redirected to the audio settings tab and a warning shows that the device is removed/invalid. Change to a different device. The redundant device should be removed on save immediately. What actually happens is that you have to save again, before the device is removed.

## Approach

Settings weren't always saved when the `bg:devices:verify-sinks` event was emitted. Moved the emission of the event in the callback to solve it.