### PR TITLE
Fixed: override chromium executable path on NixOS in puppeteer tests.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,5 @@ PATH_add node_modules/.bin
 rm node_modules/.bin/optipng
 mkdir -p node_modules/optipng-bin/vendor
 ln -sf $(which optipng) node_modules/optipng-bin/vendor/optipng
+
+export OVERRIDE_CHROMIUM_PATH=$(which chromium)

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -58,6 +58,7 @@ if (process.env[`CI_USERNAME_ALICE_${BRAND.toUpperCase()}`]) {
 */
 async function createBrowser(name, options) {
     let browser = await puppeteer.launch({
+        executablePath: process.env.OVERRIDE_CHROMIUM_PATH,
         args: [
             '--disable-notifications',
             '--disable-web-security',


### PR DESCRIPTION
### Issue number

None

### Expected behaviour

`gulp test-browser` works and uses my installed chromium on NixOS.

### Actual behaviour

The test does not find my installed chromium, while it is in the `PATH`.

### Description of fix

Added the optional env var `OVERRIDE_CHROMIUM_PATH` in  `.envrc` that will override the `executablePath` in puppeteer. If it is not specified, puppeteer will fallback to the default/current behaviour of looking for chromium.

### Other info

.
