### PR TITLE
fix: watch of plugins, yarn on NixOS.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,9 +1,18 @@
 use_nix
+
+# emacsclient can't find the socket when these are not empty.
+unset TMPDIR
+unset TMP
+unset TEMPDIR
+unset TEMP
+
 PATH_add node_modules/.bin
 
 # replace broken optipng with nix version.
-rm node_modules/.bin/optipng
-mkdir -p node_modules/optipng-bin/vendor
-ln -sf $(which optipng) node_modules/optipng-bin/vendor/optipng
+if optipng=$(which optipng); then
+  mkdir -p node_modules/optipng-bin/vendor
+  rm -f node_modules/.bin/optipng node_modules/optipng-bin/vendor/optipng
+  ln -sf $optipng node_modules/optipng-bin/vendor/optipng
+fi
 
 export OVERRIDE_CHROMIUM_PATH=$(which chromium)

--- a/default.nix
+++ b/default.nix
@@ -2,10 +2,20 @@
 
 with nixpkgs;
 
+let
+
+  node10 = nodejs-10_x;
+  yarn10 = yarn.override {
+    nodejs = node10;
+  };
+
+in
+
 mkShell {
   buildInputs = [
     # node runtime.
-    nodejs-10_x
+    node10
+    yarn10
 
     # for compiling optipng, gifsicle and jpegtran
     # autoconf zlib nasm automake

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -500,10 +500,10 @@ gulp.task('watch', 'Run developer watch modus.', () => {
 
     gulp.watch([
         path.join(settings.SRC_DIR, 'js', 'i18n', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-adapter-*', 'src', 'js', 'i18n', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-addon-*', 'src', 'js', 'i18n', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-mod-*', 'src', 'js', 'i18n', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-provider-*', 'src', 'js', 'i18n', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-adapter-*', 'src', 'js', 'i18n', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-addon-*', 'src', 'js', 'i18n', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-mod-*', 'src', 'js', 'i18n', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-provider-*', 'src', 'js', 'i18n', '*.js'),
     ], function() {
         WATCH_TASK = 'js-app-i18n'
         runSequence('js-app-i18n')
@@ -530,10 +530,10 @@ gulp.task('watch', 'Run developer watch modus.', () => {
 
     gulp.watch([
         // Glob for addons and custom modules includes both component and module js.
-        path.join(settings.NODE_PATH, 'vjs-adapter-*', 'src', '**', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-addon-*', 'src', '**', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-mod-*', 'src', '**', '*.js'),
-        path.join(settings.NODE_PATH, 'vjs-provider-*', 'src', '**', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-adapter-*', 'src', '**', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-addon-*', 'src', '**', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-mod-*', 'src', '**', '*.js'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-provider-*', 'src', '**', '*.js'),
     ], function() {
         WATCH_TASK = 'js-app-plugins'
         runSequence('js-app-plugins')
@@ -550,8 +550,8 @@ gulp.task('watch', 'Run developer watch modus.', () => {
     gulp.watch([
         path.join(settings.SRC_DIR, 'scss', '**', '*.scss'),
         path.join(settings.SRC_DIR, 'components', '**', '*.scss'),
-        path.join(settings.NODE_PATH, 'vjs-addon-*', 'src', 'components', '**', '*.scss'),
-        path.join(settings.NODE_PATH, 'vjs-mod-*', 'src', 'components', '**', '*.scss'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-addon-*', 'src', 'components', '**', '*.scss'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-mod-*', 'src', 'components', '**', '*.scss'),
         `!${path.join(settings.SRC_DIR, 'scss', 'vialer-js', 'observer.scss')}`,
     ], ['scss-app'])
 
@@ -560,8 +560,8 @@ gulp.task('watch', 'Run developer watch modus.', () => {
 
     gulp.watch([
         path.join(settings.SRC_DIR, 'components', '**', '*.vue'),
-        path.join(settings.NODE_PATH, 'vjs-addon-*', 'src', 'components', '**', '*.vue'),
-        path.join(settings.NODE_PATH, 'vjs-mod-*', 'src', 'components', '**', '*.vue'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-addon-*', 'src', 'components', '**', '*.vue'),
+        path.join(settings.NODE_PATH, '@vialer', 'vjs-mod-*', 'src', 'components', '**', '*.vue'),
     ], ['templates'])
 
     gulp.watch([path.join(settings.ROOT_DIR, 'test', 'bg', '**', '*.js')], ['test-unit'])


### PR DESCRIPTION
### Issue number

Actual issue is here: https://github.com/vialer/vjs-adapter-user-vg/pull/1
These are the changes that were needed to develop it.

By default Yarn is build on nodejs v8 on NixOS. In `default.nix` there now is a yarn derivation that is build on nodejs v10.

Also the new location of the plugins (@vialer/...) had to be updated in the gulp watch locations.

### Expected behaviour

{what should have happened}

### Actual behaviour

{what happens}

### Description of fix

{small description of what fixes the issue}

### Other info

{anything else that might be related/useful}
