### PR TITLE
fix: small bugs.

### DIFF
--- a/src/js/bg/plugins/contacts/endpoint/presence/sip.js
+++ b/src/js/bg/plugins/contacts/endpoint/presence/sip.js
@@ -65,7 +65,9 @@ class PresenceSip extends Presence {
     */
     subscribe() {
         return new Promise((resolve, reject) => {
-            this.subscription = this.app.plugins.calls.ua.subscribe(`${this.endpoint.state.id}@voipgrid.nl`, 'dialog')
+            const options = {expires: 3600}
+            this.subscription = this.app.plugins.calls.ua.subscribe(
+                `${this.endpoint.state.id}@voipgrid.nl`, 'dialog', options)
             this.subscription.on('notify', (notification) => {
                 const status = this._statusFromDialog(notification)
                 setTimeout(() => {

--- a/src/js/observer/index.js
+++ b/src/js/observer/index.js
@@ -111,7 +111,7 @@ class AppTab extends Skeleton {
             if (e.target.nodeName === 'A') {
                 // Handle links with hrefs starting with `tel:`.
                 const href = e.target.getAttribute('href')
-                if (href.startsWith('tel:')) {
+                if (href && href.startsWith('tel:')) {
                     e.preventDefault()
                     if (e.target.classList.contains('ctd-disabled')) return
                     const number = href.substring(4)


### PR DESCRIPTION
No official issues. Encountered these while developping.

When enabling `traceSip`, a lot of warnings are generated about the the "missing" option `expires` in `SipUA.subscribe`. The option is not really missing, but to suppress the excessive warnings I added the default (3600) explicity in the call.

As for the observer: sometimes I encountered `A` elements without a `href` attribute, the observer script would throw an exception on that.
