### PR TITLE
fix: electron build in NixOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,11 +8,15 @@ unset TEMP
 
 PATH_add node_modules/.bin
 
-# replace broken optipng with nix version.
-if optipng=$(which optipng); then
-  mkdir -p node_modules/optipng-bin/vendor
-  rm -f node_modules/.bin/optipng node_modules/optipng-bin/vendor/optipng
-  ln -sf $optipng node_modules/optipng-bin/vendor/optipng
-fi
+function replace {
+  if file=$(which $1); then
+    mkdir -p $(basename $2)
+    rm -f node_modules/.bin/$1 $2
+    ln -sf $file $2
+  fi
+}
+
+replace optipng node_modules/optipng-bin/vendor/optipng
+replace electron node_modules/electron/dist/electron
 
 export OVERRIDE_CHROMIUM_PATH=$(which chromium)

--- a/default.nix
+++ b/default.nix
@@ -23,5 +23,7 @@ mkShell {
     optipng
     gifsicle
     libjpeg  # for jpegtran
+
+    electron
   ];
 }


### PR DESCRIPTION
Overrides the node_modules supplied electron binary in with the electron package in NixOS